### PR TITLE
Update to modern syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ witch easy discover all cameras with this service.
 Requirement
 ===========
 
-You need Python 3.x to use this library.
+You need Python 3.5 or greater to use this library.
 
 Usage and documentation
 =======================

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ provides =
   upnp
 
 [options]
-python_requires = >3.0
+python_requires = >3.5
 packages = upnp
 
 setup_requires =

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 from os import path, getenv
 
-version = '1.0.3'
+version = '1.0.4'
 release = getenv('TRAVIS_TAG', '0.1.dev10')
 cmdclass = {}
 cmdopts = {}

--- a/upnp/HTTP.py
+++ b/upnp/HTTP.py
@@ -254,7 +254,7 @@ class HttpServer:
         """
         self.config = config
 
-    def InConnection(self, reader, writer):
+    async def InConnection(self, reader, writer):
         """
         A new incomming connection
 
@@ -264,13 +264,13 @@ class HttpServer:
         :type writer: asyncio.StreamWriter
         """
 
-        header = yield from reader.readline()
+        header = await reader.readline()
         cheaders = header.decode('latin1').strip()
         method, path, vers = cheaders.split(' ')
         headers = dict()
 
         while not reader.at_eof():
-            rawheaders = yield from reader.readline()
+            rawheaders = await reader.readline()
             headline = rawheaders.decode('latin1').strip().lower()
             if headline == '':
                 break


### PR DESCRIPTION
With Python 3.8, the 'yield from' syntax seems to not work. This patch updates the code to the new 'async/await' syntax.